### PR TITLE
Revise Bi-weekly Sync Workflow to Properly Skip at After Week Check

### DIFF
--- a/.github/workflows/bi-weekly.yml
+++ b/.github/workflows/bi-weekly.yml
@@ -13,16 +13,19 @@ jobs:
         id: week-check
         run: |
           WEEK_NUMBER=$(date +'%V')
-          if [ $((10#$WEEK_NUMBER % 2)) -ne 0 ]; then
+          IS_EVEN_WEEK=$((10#$WEEK_NUMBER % 2 == 0 ? 1 : 0))
+
+          if [ "$IS_EVEN_WEEK" -eq 1 ]; then
+            SATURDAY_DATE=$(date -d 'saturday' +'%d/%m/%y')
+            echo "::set-output name=saturday_date::$SATURDAY_DATE"
+            echo "This is an even week, sending the message."
+          else
             echo "This is an odd week, skipping the message."
-            exit 0
           fi
-          echo "This is an even week, sending the message."
-          SATURDAY_DATE=$(date -d 'saturday' +'%d/%m/%y')
-          echo "::set-output name=saturday_date::$SATURDAY_DATE"
+          echo "::set-output name=is_even_week::$IS_EVEN_WEEK"
 
       - name: Discord notification
-        if: steps.week-check.outcome == 'success'
+        if: steps.week-check.outputs.is_even_week == '1'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.2


### PR DESCRIPTION
Revise the bi-weekly sync workflow (bi-weekly.yaml) to properly skip execution after the week check.

[The workflow did not skip after the week check](https://github.com/yorkie-team/community/actions/runs/13282006268/job/37082217748) because the exit 0 code in the week-check step caused the step to be marked as [success](https://docs.github.com/en/actions/sharing-automations/creating-actions/setting-exit-codes-for-actions). As a result, the following step, which checks [if steps.week-check.outcome == 'success'](https://docs.github.com/ko/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs), was incorrectly evaluated as true.

This update explicitly sets the output of the week-check result and updates the following step to check that output instead.